### PR TITLE
Fix a problem in the `README.md` instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ This MCP server requires Python 3.10 or higher.
 Run the setup script to automatically install dependencies and configure for Claude Desktop:
 
 ```bash
-cd claude-document-mcp
+git clone https://github.com/alejandroBallesterosC/document-edit-mcp
+cd document-edit-mcp
 ./setup.sh
 ```
 


### PR DESCRIPTION
The instructions say to go to `cd claude_document_mcp` to run `./setup.sh` but this is incorrect, the script actually exists in the root of the repo.

Cheers.